### PR TITLE
Teach Flathub's external data checker to look for updates

### DIFF
--- a/com.valvesoftware.SteamLink.metainfo.xml
+++ b/com.valvesoftware.SteamLink.metainfo.xml
@@ -3,7 +3,7 @@
   <id>com.valvesoftware.SteamLink</id>
   <launchable type="desktop-id">com.valvesoftware.SteamLink.desktop</launchable>
   <metadata_license>MIT</metadata_license>
-  <project_license>LicenseRef-Proprietary</project_license>
+  <project_license>LicenseRef-proprietary</project_license>
   <name>Steam Link</name>
   <summary>Stream games from another computer with Steam</summary>
   <description>

--- a/com.valvesoftware.SteamLink.metainfo.xml
+++ b/com.valvesoftware.SteamLink.metainfo.xml
@@ -2,6 +2,8 @@
 <component type="desktop-application">
   <id>com.valvesoftware.SteamLink</id>
   <launchable type="desktop-id">com.valvesoftware.SteamLink.desktop</launchable>
+  <!-- Copyright 2003-2021 Valve Corp. -->
+  <!-- Copyright 2021 Collabora Ltd. -->
   <metadata_license>MIT</metadata_license>
   <project_license>LicenseRef-proprietary</project_license>
   <name>Steam Link</name>

--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -173,7 +173,7 @@ modules:
   - name: steamlink-binary
     sources:
       - type: archive
-        url: https://repo.steampowered.com/hidden/steamlink/b8b1b94651e7a4cfd6335180697cd35dda771058f942900b5775a69720d218c8/steamlink-1.1.73.179.tgz
+        url: https://repo.steampowered.com/steamlink/1.1.73.179/steamlink-1.1.73.179.tgz
         sha256: b8b1b94651e7a4cfd6335180697cd35dda771058f942900b5775a69720d218c8
         strip-components: 1
         x-checker-data:

--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -176,6 +176,12 @@ modules:
         url: https://repo.steampowered.com/hidden/steamlink/b8b1b94651e7a4cfd6335180697cd35dda771058f942900b5775a69720d218c8/steamlink-1.1.73.179.tgz
         sha256: b8b1b94651e7a4cfd6335180697cd35dda771058f942900b5775a69720d218c8
         strip-components: 1
+        x-checker-data:
+          is-main-source: true
+          type: html
+          url: https://repo.steampowered.com/steamlink/latest/
+          version-pattern: "href=\"steamlink-(\\d[\\d.-]*)\\.tgz\""
+          url-template: https://repo.steampowered.com/steamlink/$version/steamlink-$version.tgz
     buildsystem: simple
     build-commands:
       - "install bin/steamlink /app/bin"


### PR DESCRIPTION
* Teach Flathub's external data checker to look for updates

* Use shorter URL for steamlink binaries

* Use preferred case combination for LicenseRef-proprietary
    
    Otherwise GNOME Software 3.38.1 thinks it's FOSS, which is amusing but
    not really appropriate.

* Add copyright notices to metainfo