### PR TITLE
Enable Wayland support in Qt, use it if available

### DIFF
--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -8,7 +8,6 @@ finish_args:
   - --device=all
   - --env=LD_LIBRARY_PATH=/app/lib
   - --env=SDL_GAMECONTROLLERCONFIG_FILE=/var/data/Valve Corporation/SteamLink/controller_map.txt
-  - --env=QT_QPA_PLATFORM=xcb
   - --share=ipc
   - --share=network
   - --socket=pulseaudio

--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -95,6 +95,29 @@ modules:
           - https://repo.steampowered.com/steamlink/qtsvg-everywhere-src-5.14.1.tar.xz
         sha256: 8540a57312f815f81a45b891b49959d776727fde17579bb6bf1a537996bc9359
 
+  - name: qt5-wayland
+    buildsystem: qmake
+    cleanup:
+      - /bin
+      - /include
+      - /lib/*.a
+      - /lib/*.la
+      - /lib/*.prl
+      - /lib/cmake
+      - /lib/debug
+      - /lib/mkspecs
+      - /lib/pkgconfig
+    sources:
+      - type: archive
+        url: http://download.qt.io/archive/qt/5.14/5.14.1/submodules/qtwayland-everywhere-src-5.14.1.tar.xz
+        mirror-urls:
+          - https://repo.steampowered.com/steamlink/qtwayland-everywhere-src-5.14.1.tar.xz
+        sha256: 2a03b9f554e88c5824ef237c814b3dd45844c022e97be0e091f4a502ca4c9520
+      - type: patch
+        path: patches/org.kde.Sdk/qtwayland-use-gnome-platform-theme-on-gnome-based-desktops.patch
+      - type: patch
+        path: patches/backports/Fix-installing-qtwayland-without-qtquick-or-opengl-s.patch
+
   - name: extra-cmake-modules
     buildsystem: cmake-ninja
     cleanup:

--- a/patches/backports/Fix-installing-qtwayland-without-qtquick-or-opengl-s.patch
+++ b/patches/backports/Fix-installing-qtwayland-without-qtquick-or-opengl-s.patch
@@ -1,0 +1,43 @@
+From: Kai Koehne <kai.koehne@qt.io>
+Date: Tue, 3 Mar 2020 16:30:11 +0100
+Subject: Fix installing qtwayland without qtquick or opengl support
+
+Unconditionally generate qwayland-server-qt-texture-sharing-unstable-v1.h,
+even if the header file will not be used. It is listed in syncqt.profile though,
+and because of
+
+  private_headers.CONFIG += no_check_exist
+
+in extensions.pri qmake will unconditionally generate an install rule.
+
+Fixes: QTBUG-82569
+Change-Id: I5125382f1e4fc61936515e045a7e6a4a3c608451
+Reviewed-by: Joerg Bornemann <joerg.bornemann@qt.io>
+Origin: upstream, commit:0f0fbf0a70940379a99618d2069721471e3fc631
+---
+ src/compositor/extensions/extensions.pri | 4 +---
+ 1 file changed, 1 insertion(+), 3 deletions(-)
+
+diff --git a/src/compositor/extensions/extensions.pri b/src/compositor/extensions/extensions.pri
+index 61ab043e..06e3ef9e 100644
+--- a/src/compositor/extensions/extensions.pri
++++ b/src/compositor/extensions/extensions.pri
+@@ -8,6 +8,7 @@ WAYLANDSERVERSOURCES += \
+     ../extensions/touch-extension.xml \
+     ../extensions/qt-key-unstable-v1.xml \
+     ../extensions/qt-windowmanager.xml \
++    ../extensions/qt-texture-sharing-unstable-v1.xml \
+     ../3rdparty/protocol/text-input-unstable-v2.xml \
+     ../3rdparty/protocol/viewporter.xml \
+     ../3rdparty/protocol/scaler.xml \
+@@ -96,9 +97,6 @@ qtHaveModule(quick) {
+         extensions/qwaylandxdgshellintegration.cpp \
+ 
+     qtConfig(opengl) {
+-        WAYLANDSERVERSOURCES += \
+-            ../extensions/qt-texture-sharing-unstable-v1.xml
+-
+         HEADERS += \
+             extensions/qwltexturesharingextension_p.h
+ 
+-- 

--- a/patches/org.kde.Sdk/qtwayland-use-gnome-platform-theme-on-gnome-based-desktops.patch
+++ b/patches/org.kde.Sdk/qtwayland-use-gnome-platform-theme-on-gnome-based-desktops.patch
@@ -1,0 +1,40 @@
+diff --git a/src/client/qwaylandintegration.cpp b/src/client/qwaylandintegration.cpp
+index 97e0203c..5bee160a 100644
+--- a/src/client/qwaylandintegration.cpp
++++ b/src/client/qwaylandintegration.cpp
+@@ -99,20 +99,26 @@ public:
+ 
+         if (QGuiApplication::desktopSettingsAware()) {
+             const QByteArray desktopEnvironment = QGuiApplicationPrivate::platformIntegration()->services()->desktopEnvironment();
+-
++            QList<QByteArray> gtkBasedEnvironments;
++            gtkBasedEnvironments << "GNOME"
++                                 << "X-CINNAMON"
++                                 << "UNITY"
++                                 << "MATE"
++                                 << "XFCE"
++                                 << "LXDE";
+             if (desktopEnvironment == QByteArrayLiteral("KDE")) {
+ #if QT_CONFIG(settings)
+                 result.push_back(QStringLiteral("kde"));
+ #endif
+-            } else if (!desktopEnvironment.isEmpty() &&
+-                desktopEnvironment != QByteArrayLiteral("UNKNOWN") &&
+-                desktopEnvironment != QByteArrayLiteral("GNOME") &&
+-                desktopEnvironment != QByteArrayLiteral("UNITY") &&
+-                desktopEnvironment != QByteArrayLiteral("MATE") &&
+-                desktopEnvironment != QByteArrayLiteral("XFCE") &&
+-                desktopEnvironment != QByteArrayLiteral("LXDE"))
++            } else if (gtkBasedEnvironments.contains(desktopEnvironment)) {
++                // prefer the GTK3 theme implementation with native dialogs etc.
++                result.push_back(QStringLiteral("gtk3"));
++                // fallback to the generic Gnome theme if loading the GTK3 theme fails
++                result.push_back(QLatin1String(QGnomeTheme::name));
++            } else if (!desktopEnvironment.isEmpty() && desktopEnvironment != QByteArrayLiteral("UNKNOWN")) {
+                 // Ignore X11 desktop environments
+                 result.push_back(QString::fromLocal8Bit(desktopEnvironment.toLower()));
++            }
+         }
+ 
+         if (result.isEmpty())
+


### PR DESCRIPTION
* Compile native Wayland support plugin for Qt
    
    We'll use this to give the UI shell Wayland support.

* Revert "Fixed bug #6, explicitly set the QT platform for the shell"
    
    Now that we have Qt's platform plugin for Wayland, we can use that
    for the shell. This is a step towards not needing X11 at all.
    
    Test with:
    
        Xephyr :2 &
        DISPLAY=:2 flatpak run com.valvesoftware.SteamLink//master
    
    Previously, both the shell (UI layer) and the actual streaming client
    would run on the Xephyr display. After this change, the shell runs
    full-screen again (via Wayland), and the actual streaming client uses
    X11 by default.
    
    The streaming client can be forced to use Wayland too by setting
    environment variable SDL_VIDEODRIVER=wayland.
    
    This reverts commit 9845f4fe7b4b24591ef417a71773dcdc28b7e88e.

---

@lhindir, please could you try this out in your Wayland environment? Let us know whether it works well, what your Wayland environment is, and which Qt and SDL environment variables you're forcing (if any).

It seemed OK for me in some brief testing in GNOME Shell 3.38, but I haven't tried it in other Wayland environments like KDE Plasma or Sway.