### PR TITLE
Only share X11 display with the app if Wayland is unavailable

### DIFF
--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -10,6 +10,7 @@ finish_args:
   - --env=SDL_GAMECONTROLLERCONFIG_FILE=/var/data/Valve Corporation/SteamLink/controller_map.txt
   - --share=ipc
   - --share=network
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
   - --socket=x11


### PR DESCRIPTION
This improves the isolation between the app's sandbox and the host
system when running in a Wayland-capable environment, such as
GNOME Shell in its default Wayland mode (tested on Debian 11) or
KDE Plasma Desktop in its non-default Wayland mode (not tested).

The UI shell uses Qt, which was given Wayland support in the previous
commit.

The actual streaming client uses SDL, which defaults to X11 but will
use Wayland if no X11 display is available.

To test:

    Xephyr :2 &
    DISPLAY=:2 flatpak run com.valvesoftware.SteamLink//master

You should see that the Steam Link app (both the shell and the actual
streaming client) continues to run full-screen rather than being confined
to the Xephyr display, indicating that both parts are using Wayland
rather than X11.

---

Based on #15. We should probably get a beta release out with #15 merged before landing this, but this is where I'd like to get to eventually.

@lhindir, as with #15, when the flathub bot has built a test package for this, it would be great if you could try it in your Wayland environment and let us know how well it works.