### PR TITLE
Try to use a newer libva

### DIFF
--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -160,6 +160,16 @@ modules:
         commands:
           - rm -fr po
 
+  - name: vaapi
+    buildsystem: meson
+    config-opts:
+      - -Ddriverdir=/usr/lib/x86_64-linux-gnu/GL/lib/dri
+    sources:
+      - type: git
+        url: https://github.com/intel/libva.git
+        # Version 2.11.0
+        commit: 64d75c08a720b73f4474b9265ca6dc99f947af8b
+
   - name: steamlink-binary
     sources:
       - type: archive

--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -170,6 +170,13 @@ modules:
         # Version 2.11.0
         commit: 64d75c08a720b73f4474b9265ca6dc99f947af8b
 
+  - name: libva-utils
+    sources:
+      - type: git
+        url: https://github.com/intel/libva-utils.git
+        # Version 2.9.0
+        commit: ee781a3f5d70a7ff801940136b1d45d002b83091
+
   - name: steamlink-binary
     sources:
       - type: archive


### PR DESCRIPTION
A user reported having issues with the streaming image quality when he used the Flatpak version of Steam Link. Issues that don't occur with the Steam client. https://steamcommunity.com/app/353380/discussions/10/3051735285571951783

One of the differences between the two is that the Steam client is using the host libraries, including libva 2.11.1, instead Steam Link is using the fdo runtime 20.08 that has libva 2.8.0.

With this PR we can let the flathub bot build a new image that uses libva 2.11.0 (the version currently scheduled to be included in the next fdo 21.08) and try to validate the assumption that the older libva is the culprit of the reported image issues. This is not intended to be merged.

In case this assumption turns out to be true, probably the best way forward would be to backport libva 2.11.0 to the fdo Platform runtime 20.08 instead of switching to the unreleased 21.08 runtime or building and bundling our own libva.