### PR TITLE
Upgrade runtime to 21.08

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ Test-building this package locally
 * `flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`
     * Add `--user` if you prefer to install into
         `~/.local/share/flatpak` instead of `/var/lib/flatpak`
-* `flatpak install org.freedesktop.Platform/x86_64/20.08`
-* `flatpak install org.freedesktop.Sdk/x86_64/20.08`
+* `flatpak install org.freedesktop.Platform/x86_64/21.08`
+* `flatpak install org.freedesktop.Sdk/x86_64/21.08`
 
 ### Build
 
@@ -74,7 +74,7 @@ Again, `./build.sh` has a suitable command.
 * `flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo`
     * Add `--user` if you prefer to install into
         `~/.local/share/flatpak` instead of `/var/lib/flatpak`
-* `flatpak install org.freedesktop.Platform/x86_64/20.08`
+* `flatpak install org.freedesktop.Platform/x86_64/21.08`
 
 ### Install on test machine
 

--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -1,6 +1,6 @@
 app-id: com.valvesoftware.SteamLink
 runtime: org.freedesktop.Platform
-runtime-version: '20.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 command: steamlink
 
@@ -42,6 +42,12 @@ modules:
         path: patches/org.kde.Sdk/qtbase-make-sure-to-correctly-construct-base-platform-theme.patch
       - type: patch
         path: patches/org.kde.Sdk/open-file-portal-writable.patch
+      - type: patch
+        path: patches/backports/Add-missing-limits-include.patch
+      - type: patch
+        path: patches/backports/Fix-build-with-GCC-11-include-limits.patch
+      - type: patch
+        path: patches/backports/Build-fixes-for-GCC-11.patch
       - type: shell
         commands:
           - mv configure configure.qt

--- a/patches/backports/Add-missing-limits-include.patch
+++ b/patches/backports/Add-missing-limits-include.patch
@@ -1,0 +1,31 @@
+From 10b8cca7915ebe217ed81323a334980f92ffae5b Mon Sep 17 00:00:00 2001
+From: Nicolas Fella <nicolas.fella@kdab.com>
+Date: Sun, 20 Jun 2021 17:36:41 +0200
+Subject: [PATCH 3/3] Add missing limits include
+
+The code uses std::numeric_limits but is lacking the appropriate include
+
+Change-Id: I41fa5ac4d8c4e06f35b5b1551ef2ad8417df80bd
+Reviewed-by: Giuseppe D'Angelo <giuseppe.dangelo@kdab.com>
+(cherry picked from commit 2b2b3155d9f6ba1e4f859741468fbc47db09292b)
+Reviewed-by: Qt Cherry-pick Bot <cherrypick_bot@qt-project.org>
+Origin: upstream, 6.2.0-alpha1, commit:380294a5971da85010a708dc23b0edec192cbf27
+---
+ src/corelib/tools/qoffsetstringarray_p.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/corelib/tools/qoffsetstringarray_p.h b/src/corelib/tools/qoffsetstringarray_p.h
+index 4dd9e9603b..e26a57ff43 100644
+--- a/src/corelib/tools/qoffsetstringarray_p.h
++++ b/src/corelib/tools/qoffsetstringarray_p.h
+@@ -55,6 +55,7 @@
+ 
+ #include <tuple>
+ #include <array>
++#include <limits>
+ 
+ QT_BEGIN_NAMESPACE
+ 
+-- 
+2.34.0
+

--- a/patches/backports/Build-fixes-for-GCC-11.patch
+++ b/patches/backports/Build-fixes-for-GCC-11.patch
@@ -1,0 +1,59 @@
+From 1e8af17ef8e76c76f6d5fee34e4d2c79e77ca9cc Mon Sep 17 00:00:00 2001
+From: Ville Voutilainen <ville.voutilainen@qt.io>
+Date: Mon, 18 Jan 2021 09:58:17 +0200
+Subject: [PATCH 1/3] Build fixes for GCC 11
+
+Task-number: QTBUG-89977
+Change-Id: Ic1b7ddbffb8a0a00f8c621d09a868f1d94a52c21
+Reviewed-by: Lars Knoll <lars.knoll@qt.io>
+Reviewed-by: Thiago Macieira <thiago.macieira@intel.com>
+Origin: upstream, 6.1.0-alpha1, commit:813a928c7c3cf98670b6043149880ed5c955efb9
+---
+ src/corelib/text/qbytearraymatcher.h     | 2 ++
+ src/corelib/tools/qsharedpointer_impl.h  | 3 ---
+ src/plugins/platforms/xcb/qxcbwindow.cpp | 2 +-
+ 3 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/src/corelib/text/qbytearraymatcher.h b/src/corelib/text/qbytearraymatcher.h
+index 0eedfc1d20..f5f9bef7b8 100644
+--- a/src/corelib/text/qbytearraymatcher.h
++++ b/src/corelib/text/qbytearraymatcher.h
+@@ -42,6 +42,8 @@
+ 
+ #include <QtCore/qbytearray.h>
+ 
++#include <limits>
++
+ QT_BEGIN_NAMESPACE
+ 
+ 
+diff --git a/src/corelib/tools/qsharedpointer_impl.h b/src/corelib/tools/qsharedpointer_impl.h
+index 362d57fb9a..e2f31e5f8b 100644
+--- a/src/corelib/tools/qsharedpointer_impl.h
++++ b/src/corelib/tools/qsharedpointer_impl.h
+@@ -154,9 +154,6 @@ namespace QtSharedPointer {
+ #endif
+         inline void checkQObjectShared(...) { }
+         inline void setQObjectShared(...) { }
+-
+-        inline void operator delete(void *ptr) { ::operator delete(ptr); }
+-        inline void operator delete(void *, void *) { }
+     };
+     // sizeof(ExternalRefCountData) = 12 (32-bit) / 16 (64-bit)
+ 
+diff --git a/src/plugins/platforms/xcb/qxcbwindow.cpp b/src/plugins/platforms/xcb/qxcbwindow.cpp
+index cfe048d5c4..551942599d 100644
+--- a/src/plugins/platforms/xcb/qxcbwindow.cpp
++++ b/src/plugins/platforms/xcb/qxcbwindow.cpp
+@@ -717,7 +717,7 @@ void QXcbWindow::show()
+         if (isTransient(window())) {
+             const QWindow *tp = window()->transientParent();
+             if (tp && tp->handle())
+-                transientXcbParent = static_cast<const QXcbWindow *>(tp->handle())->winId();
++                transientXcbParent = tp->handle()->winId();
+             // Default to client leader if there is no transient parent, else modal dialogs can
+             // be hidden by their parents.
+             if (!transientXcbParent)
+-- 
+2.34.0
+

--- a/patches/backports/Fix-build-with-GCC-11-include-limits.patch
+++ b/patches/backports/Fix-build-with-GCC-11-include-limits.patch
@@ -1,0 +1,53 @@
+From 92fde6e1f3b8b4ed383d070cca3d5b87c57d4116 Mon Sep 17 00:00:00 2001
+From: Thiago Macieira <thiago.macieira@intel.com>
+Date: Mon, 18 Jan 2021 07:40:54 -0800
+Subject: [PATCH 2/3] Fix build with GCC 11: include <limits>
+
+Fixes: QTBUG-90395
+Change-Id: Iecc74d2000eb40dfbe7bfffd165b5dd3708b7a40
+(cherry picked from commit 9c56d4da2ff631a8c1c30475bd792f6c86bda53c)
+Reviewed-by: Edward Welbourne <edward.welbourne@qt.io>
+Origin: upstream, 6.0.1, commit:b2af6332ea37e45ab230a7a5d2d278f86d961b83
+---
+ src/corelib/global/qendian.h  | 6 ++++--
+ src/corelib/global/qfloat16.h | 1 +
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/src/corelib/global/qendian.h b/src/corelib/global/qendian.h
+index 257efbbdbe..339f53abb6 100644
+--- a/src/corelib/global/qendian.h
++++ b/src/corelib/global/qendian.h
+@@ -1,7 +1,7 @@
+ /****************************************************************************
+ **
+-** Copyright (C) 2016 The Qt Company Ltd.
+-** Copyright (C) 2016 Intel Corporation.
++** Copyright (C) 2021 The Qt Company Ltd.
++** Copyright (C) 2021 Intel Corporation.
+ ** Contact: https://www.qt.io/licensing/
+ **
+ ** This file is part of the QtCore module of the Qt Toolkit.
+@@ -44,6 +44,8 @@
+ #include <QtCore/qfloat16.h>
+ #include <QtCore/qglobal.h>
+ 
++#include <limits>
++
+ // include stdlib.h and hope that it defines __GLIBC__ for glibc-based systems
+ #include <stdlib.h>
+ #include <string.h>
+diff --git a/src/corelib/global/qfloat16.h b/src/corelib/global/qfloat16.h
+index 02fd2f03cc..27a3a158d6 100644
+--- a/src/corelib/global/qfloat16.h
++++ b/src/corelib/global/qfloat16.h
+@@ -43,6 +43,7 @@
+ 
+ #include <QtCore/qglobal.h>
+ #include <QtCore/qmetatype.h>
++#include <limits>
+ #include <string.h>
+ 
+ #if defined(QT_COMPILER_SUPPORTS_F16C) && defined(__AVX2__) && !defined(__F16C__)
+-- 
+2.34.0
+


### PR DESCRIPTION
This gives us a newer platform to run on, and in particular upgrades
libVA to 2.12.0, which might be helpful for VA-API hardware decoding
with surface modifiers.

The newer runtime has a newer gcc version, so we need to backport some
build fixes from Qt 6.

Resolves: https://github.com/flathub/com.valvesoftware.SteamLink/issues/24

---

The proprietary binaries and the libraries bundled with them (SDL and friends, and ffmpeg) are currently still built on 20.08, but I'm hoping that 20.08 and 21.08 are sufficiently compatible that they'll run successfully on a 21.08 Platform.

@slouken, when you get a chance, please could you try rebuilding the proprietary binaries on 21.08 and make sure that still works?