### PR TITLE
permissions: Allow inhibiting screensaver via D-Bus

### DIFF
--- a/com.valvesoftware.SteamLink.yml
+++ b/com.valvesoftware.SteamLink.yml
@@ -13,6 +13,7 @@ finish_args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
+  - --talk-name=org.freedesktop.ScreenSaver
 
 tags:
   - proprietary


### PR DESCRIPTION
Steam Link uses SDL_DisableScreenSaver(), which currently tries to use
org.freedesktop.ScreenSaver.Inhibit(), falling back to either an
X11-specific or Wayland-specific protocol to inhibit the screensaver.

GNOME doesn't yet implement the Wayland-specific idle-inhibit protocol,
and Steam Link wasn't previously given access to the fd.o screensaver
interface via D-Bus, resulting in the screensaver locking if Steam Link
is using Wayland and is left idle for a while. We can avoid this by
giving Steam Link access to the necessary D-Bus interface.

Ideally SDL would use xdg-desktop-portal's org.freedesktop.portal.Inhibit
interface if it detects that it's running in a Flatpak sandbox, but that
isn't yet implemented in SDL. When it is, this can be reverted.

Thanks: Steam user "YCbCr"  
Resolves: https://steamcommunity.com/app/353380/discussions/10/3466100515592406551/