### PR TITLE
Add a subcategory

### DIFF
--- a/com.valvesoftware.SteamLink.desktop
+++ b/com.valvesoftware.SteamLink.desktop
@@ -5,6 +5,6 @@ Exec=/app/bin/steamlink %u
 Icon=com.valvesoftware.SteamLink
 Terminal=false
 Type=Application
-Categories=Game;
+Categories=Game;Utility;
 MimeType=x-scheme-handler/steamlink;
 Keywords=Games


### PR DESCRIPTION
While this subcategory doesn't exist in the spec, it should still build fine and we will start using these on the website. The spec hasn't been moving, despite us trying to get things changed. Steam itself already uses an unknown subcategory, so this should also be fine.